### PR TITLE
LCM client cert management bugfixes

### DIFF
--- a/rsBasePrep.ps1
+++ b/rsBasePrep.ps1
@@ -27,17 +27,17 @@ Function Load-Globals {
          $Global:catalog = Get-rsServiceCatalog
          $Global:AuthToken = @{"X-Auth-Token"=($Global:catalog.access.token.id)}
          $Global:defaultRegion = $Global:catalog.access.user.'RAX-AUTH:defaultRegion'
-         if(($Global:catalog.access.user.roles | ? name -eq "rack_connect").id.count -gt 0) { $Global:isRackConnect = $true } else { $Global:isRackConnect = $false } 
-         if(($Global:catalog.access.user.roles | ? name -eq "rax_managed").id.count -gt 0) { $Global:isManaged = $true } else { $Global:isManaged = $false } 
+         if(($Global:catalog.access.user.roles | Where-Object name -eq "rack_connect").id.count -gt 0) { $Global:isRackConnect = $true } else { $Global:isRackConnect = $false } 
+         if(($Global:catalog.access.user.roles | Where-Object name -eq "rax_managed").id.count -gt 0) { $Global:isManaged = $true } else { $Global:isManaged = $false } 
       }
       else {
-         $Global:defaultRegion = (Get-rsDedicatedInfo | ? {$_.name -eq $env:COMPUTERNAME}).defaultRegion
-         $Global:isRackConnect = (Get-rsDedicatedInfo | ? {$_.name -eq $env:COMPUTERNAME}).isRackConnect
+         $Global:defaultRegion = (Get-rsDedicatedInfo | Where-Object {$_.name -eq $env:COMPUTERNAME}).defaultRegion
+         $Global:isRackConnect = (Get-rsDedicatedInfo | Where-Object {$_.name -eq $env:COMPUTERNAME}).isRackConnect
          $Global:isManaged = $true
       }
       $Global:pullServerName = $env:COMPUTERNAME
       $Global:pullServerPublicIP = Get-rsAccessIPv4
-      $Global:pullServerPrivateIP = (Get-NetAdapter | ? status -eq 'up' | Get-NetIPAddress -ea 0 | ? IPAddress -match '^10\.').IPAddress
+      $Global:pullServerPrivateIP = (Get-NetAdapter | Where-Object status -eq 'up' | Get-NetIPAddress -ea 0 | Where-Object IPAddress -match '^10\.').IPAddress
       $Global:pullServerRegion = Get-rsRegion -Value $env:COMPUTERNAME
    }
    else 
@@ -411,7 +411,7 @@ Function Update-HostFile {
    $pullServerPublicIP = $pullserverInfo.pullserverPublicIp
    $pullServerPrivateIP = $pullServerInfo.pullServerPrivateIp
    if((Get-rsRole -Value $env:COMPUTERNAME) -eq "pull") {
-      $hostContent = ((Get-NetAdapter | ? status -eq 'up' | Get-NetIPAddress -ea 0 | ? IPAddress -like '10.*').IPAddress + "`t`t`t" + $env:COMPUTERNAME)
+      $hostContent = ((Get-NetAdapter | Where-Object status -eq 'up' | Get-NetIPAddress -ea 0 | Where-Object IPAddress -like '10.*').IPAddress + "`t`t`t" + $env:COMPUTERNAME)
       Add-Content -Path "C:\Windows\System32\Drivers\etc\hosts" -Value $hostContent -Force
       Write-EventLog -LogName DevOps -Source BasePrep -EntryType Information -EventId 1000 -Message "Adding $hostContent to PullServer Hosts File"
       return
@@ -427,7 +427,7 @@ Function Update-HostFile {
       Add-Content -Path "C:\Windows\System32\Drivers\etc\hosts" -Value $hostContent -Force
       Write-EventLog -LogName DevOps -Source BasePrep -EntryType Information -EventId 1000 -Message "PullServerRegion $pullServerRegion`nServerRegion $(Get-rsRegion -Value $env:COMPUTERNAME)"
       Write-EventLog -LogName DevOps -Source BasePrep -EntryType Information -EventId 1000 -Message "Adding $hostContent to HostsFile"
-      $hostContent = ((Get-NetAdapter | ? status -eq 'up' | Get-NetIPAddress -ea 0 | ? IPAddress -like '10.*').IPAddress + "`t`t`t" + $env:COMPUTERNAME)
+      $hostContent = ((Get-NetAdapter | Where-Object status -eq 'up' | Get-NetIPAddress -ea 0 | Where-Object IPAddress -like '10.*').IPAddress + "`t`t`t" + $env:COMPUTERNAME)
       Add-Content -Path "C:\Windows\System32\Drivers\etc\hosts" -Value $hostContent -Force
       Write-EventLog -LogName DevOps -Source BasePrep -EntryType Information -EventId 1000 -Message "Adding $hostContent to HostsFile"
       return

--- a/rsLCM.ps1
+++ b/rsLCM.ps1
@@ -106,11 +106,11 @@ else {
 
     if (($gitSyncSuccess))
     {
-        Write-EventLog -LogName DevOps -Source LCM -EntryType Information -EventId 1000 -Message "Client certificate push complete after $certSyncAttempt attempt(s)."
+        Write-EventLog -LogName DevOps -Source LCM -EntryType Information -EventId 1000 -Message "Client certificate push complete after $certSyncAttempt attempt(s).`n Git FETCH: $($gitFetch.ExitCode) `n Git MERGE: $($gitMerge.ExitCode) `n Git PUSH: $($gitPush.ExitCode)"
     }
     else 
     {
-        Write-EventLog -LogName DevOps -Source LCM -EntryType Error -EventId 1000 -Message "Client certificate push failed after $certSyncAttempt attempts. `n Please Re-run rsLCM process manually to correct this as client MOF will not be generated for this host."
+        Write-EventLog -LogName DevOps -Source LCM -EntryType Error -EventId 1000 -Message "Client certificate push failed after $certSyncAttempt attempts. `n Please Re-run rsLCM process manually to correct this as client MOF will not be generated for this host.`n Git FETCH: $($gitFetch.ExitCode) `n Git MERGE: $($gitMerge.ExitCode) `n Git PUSH: $($gitPush.ExitCode)"
     }
    
    chdir "C:\Windows\Temp"

--- a/rsLCM.ps1
+++ b/rsLCM.ps1
@@ -106,7 +106,7 @@ else {
 
     if (($gitSyncSuccess))
     {
-        Write-EventLog -LogName DevOps -Source LCM -EntryType Information -EventId 1000 -Message "Client certificate push complete after $certSyncRetries attempt(s)."
+        Write-EventLog -LogName DevOps -Source LCM -EntryType Information -EventId 1000 -Message "Client certificate push complete after $certSyncAttempt attempt(s)."
     }
     else 
     {

--- a/rsLCM.ps1
+++ b/rsLCM.ps1
@@ -91,7 +91,7 @@ else {
         $gitMerge = Start-Process -PassThru -Wait "C:\Program Files (x86)\Git\bin\git.exe" -ArgumentList "merge remotes/origin/$($d.branch_rsConfigs)"    
         $gitPush = Start-Process -PassThru -Wait "C:\Program Files (x86)\Git\bin\git.exe" -ArgumentList "push origin $($d.branch_rsConfigs)"
 
-        if (($gitFetch.ExitCode -eq 0) -or ($gitMerge.ExitCode -eq 0) -or ($gitPush.ExitCode -eq 0))
+        if (($gitFetch.ExitCode -eq 0) -and ($gitMerge.ExitCode -eq 0) -and ($gitPush.ExitCode -eq 0))
         {
             $gitSyncSuccess = $true
         }

--- a/rsLCM.ps1
+++ b/rsLCM.ps1
@@ -110,7 +110,7 @@ else {
     }
     else 
     {
-        Write-EventLog -LogName DevOps -Source LCM -EntryType Error -EventId 1000 -Message "Client certificate push failed after $certSyncRetries attempts. `n Please Re-run rsLCM process manually to correct this as client MOF will not be generated for this host."
+        Write-EventLog -LogName DevOps -Source LCM -EntryType Error -EventId 1000 -Message "Client certificate push failed after $certSyncAttempt attempts. `n Please Re-run rsLCM process manually to correct this as client MOF will not be generated for this host."
     }
    
    chdir "C:\Windows\Temp"

--- a/rsLCM.ps1
+++ b/rsLCM.ps1
@@ -87,9 +87,9 @@ else {
     
     Do
     {
-        $gitFetch = Start-Process -PassThru -Wait "C:\Program Files (x86)\Git\bin\git.exe" -ArgumentList commit "fetch origin $($d.branch_rsConfigs)"
-        $gitMerge = Start-Process -PassThru -Wait "C:\Program Files (x86)\Git\bin\git.exe" -ArgumentList commit "merge remotes/origin/$($d.branch_rsConfigs)"    
-        $gitPush = Start-Process -PassThru -Wait "C:\Program Files (x86)\Git\bin\git.exe" -ArgumentList commit "push origin $($d.branch_rsConfigs)"
+        $gitFetch = Start-Process -PassThru -Wait "C:\Program Files (x86)\Git\bin\git.exe" -ArgumentList "fetch origin $($d.branch_rsConfigs)"
+        $gitMerge = Start-Process -PassThru -Wait "C:\Program Files (x86)\Git\bin\git.exe" -ArgumentList "merge remotes/origin/$($d.branch_rsConfigs)"    
+        $gitPush = Start-Process -PassThru -Wait "C:\Program Files (x86)\Git\bin\git.exe" -ArgumentList "push origin $($d.branch_rsConfigs)"
 
         if (($gitFetch.ExitCode -eq 0) -or ($gitMerge.ExitCode -eq 0) -or ($gitPush.ExitCode -eq 0))
         {

--- a/rsLCM.ps1
+++ b/rsLCM.ps1
@@ -43,8 +43,6 @@ Configuration PullServerLCM
 . "$("C:\DevOps", $d.mR, 'PullServerInfo.ps1' -join '\' )"
 New-rsEventLogSource -logSource LCM
 
-$gitPath = "C:\Program Files (x86)\Git\bin\git.exe"
-
 if(Test-rsCloud) {
    $ObjectGuid = (Get-rsXenInfo -value name) -replace "instance-", ""
 }
@@ -65,16 +63,16 @@ else {
    $Node = $env:COMPUTERNAME
    $cN = "CN=" + $Node + "_enc"
    Set-Location -Path ("C:\DevOps", $d.mR -join "\")
-   Start -Wait $gitPath -ArgumentList "fetch origin $($d.branch_rsConfigs)"
-   Start -Wait $gitPath -ArgumentList "merge remotes/origin/$($d.branch_rsConfigs)"
+   Start -Wait "C:\Program Files (x86)\Git\bin\git.exe" -ArgumentList "fetch origin $($d.branch_rsConfigs)"
+   Start -Wait "C:\Program Files (x86)\Git\bin\git.exe" -ArgumentList "merge remotes/origin/$($d.branch_rsConfigs)"
    
    if (!(Test-Path -Path $("C:\DevOps", $d.mR, "Certificates", "Credentials" -join '\')))
    {
       New-Item -Path $("C:\DevOps", $d.mR, "Certificates", "Credentials" -join '\') -ItemType directory
    }
    powershell.exe "C:\DevOps\rsProvisioning\makecert.exe" -r -pe -n $cN -sky exchange -ss my $("C:\DevOps", $d.mR, "Certificates\Credentials","$ObjectGuid.cer"  -join '\'), -sr localmachine, -len 2048
-   Start -Wait $gitPath -ArgumentList "add $("C:\DevOps", $d.mR, "Certificates\Credentials","$ObjectGuid.cer"  -join '\')"
-   Start -Wait $gitPath -ArgumentList "commit -a -m `"pushing $ObjectGuid.crt`""
+   Start -Wait "C:\Program Files (x86)\Git\bin\git.exe" -ArgumentList "add $("C:\DevOps", $d.mR, "Certificates\Credentials","$ObjectGuid.cer"  -join '\')"
+   Start -Wait "C:\Program Files (x86)\Git\bin\git.exe" -ArgumentList "commit -a -m `"pushing $ObjectGuid.crt`""
    
    <# Commenting out below commands as they have been replaced by new logic below
    Start -Wait "C:\Program Files (x86)\Git\bin\git.exe" -ArgumentList "fetch origin $($d.branch_rsConfigs)"
@@ -89,9 +87,9 @@ else {
     
     Do
     {
-        $gitFetch = Start-Process -WindowStyle Hidden -PassThru -Wait $gitPath -ArgumentList commit "fetch origin $($d.branch_rsConfigs)"
-        $gitMerge = Start-Process -WindowStyle Hidden -PassThru -Wait $gitPath -ArgumentList commit "merge remotes/origin/$($d.branch_rsConfigs)"    
-        $gitPush = Start-Process -WindowStyle Hidden -PassThru -Wait $gitPath -ArgumentList commit "push origin $($d.branch_rsConfigs)"
+        $gitFetch = Start-Process -PassThru -Wait "C:\Program Files (x86)\Git\bin\git.exe" -ArgumentList commit "fetch origin $($d.branch_rsConfigs)"
+        $gitMerge = Start-Process -PassThru -Wait "C:\Program Files (x86)\Git\bin\git.exe" -ArgumentList commit "merge remotes/origin/$($d.branch_rsConfigs)"    
+        $gitPush = Start-Process -PassThru -Wait "C:\Program Files (x86)\Git\bin\git.exe" -ArgumentList commit "push origin $($d.branch_rsConfigs)"
 
         if (($gitFetch.ExitCode -eq 0) -or ($gitMerge.ExitCode -eq 0) -or ($gitPush.ExitCode -eq 0))
         {

--- a/rsLCM.ps1
+++ b/rsLCM.ps1
@@ -2,78 +2,86 @@
 
 Configuration ClientLCM
 {
-   param ($Node, $pullServerUri, $ObjectGuid, $CertificateID)
-   
-   Node $Node
-   {
-      LocalConfigurationManager
-      {
-         AllowModuleOverwrite = 'True'
-         ConfigurationID = $ObjectGuid
-         CertificateID = $CertificateID
-         ConfigurationModeFrequencyMins = 30
-         ConfigurationMode = 'ApplyAndAutoCorrect'
-         RebootNodeIfNeeded = 'True'
-         RefreshMode = 'Pull'
-         RefreshFrequencyMins = 15
-         DownloadManagerName = 'WebDownloadManager'
-         DownloadManagerCustomData = (@{ServerUrl = $pullServerUri; AllowUnsecureConnection = "false"})
-      }
-   }
+    param ($Node, $pullServerUri, $ObjectGuid, $CertificateID)
+    
+    Node $Node
+    {
+        LocalConfigurationManager
+        {
+            AllowModuleOverwrite = 'True'
+            ConfigurationID = $ObjectGuid
+            CertificateID = $CertificateID
+            ConfigurationModeFrequencyMins = 30
+            ConfigurationMode = 'ApplyAndAutoCorrect'
+            RebootNodeIfNeeded = 'True'
+            RefreshMode = 'Pull'
+            RefreshFrequencyMins = 15
+            DownloadManagerName = 'WebDownloadManager'
+            DownloadManagerCustomData = (@{ServerUrl = $pullServerUri; AllowUnsecureConnection = "false"})
+        }
+    }
 }
 
 Configuration PullServerLCM
 {
-   
-   Node $env:COMPUTERNAME
-   {
-      LocalConfigurationManager
-      {
-         AllowModuleOverwrite = 'True'
-         ConfigurationModeFrequencyMins = 30
-         ConfigurationMode = 'ApplyAndAutoCorrect'
-         RebootNodeIfNeeded = 'True'
-         RefreshMode = 'PUSH'
-         RefreshFrequencyMins = 15
-      }
-   }
+    
+    Node $env:COMPUTERNAME
+    {
+        LocalConfigurationManager
+        {
+            AllowModuleOverwrite = 'True'
+            ConfigurationModeFrequencyMins = 30
+            ConfigurationMode = 'ApplyAndAutoCorrect'
+            RebootNodeIfNeeded = 'True'
+            RefreshMode = 'PUSH'
+            RefreshFrequencyMins = 15
+        }
+    }
 }
 
 . (Get-rsSecrets)
 . "$("C:\DevOps", $d.mR, 'PullServerInfo.ps1' -join '\' )"
 New-rsEventLogSource -logSource LCM
 
-if(Test-rsCloud) {
-   $ObjectGuid = (Get-rsXenInfo -value name) -replace "instance-", ""
+if(Test-rsCloud) 
+{
+    $ObjectGuid = (Get-rsXenInfo -value name) -replace "instance-", ""
 }
-else {
-   $ObjectGuid = ((Get-rsDedicatedInfo -Value $env:COMPUTERNAME) | ? { $_.name -eq $env:COMPUTERNAME } ).id
+else 
+{
+    $ObjectGuid = ((Get-rsDedicatedInfo -Value $env:COMPUTERNAME) | ? { $_.name -eq $env:COMPUTERNAME } ).id
 }
 
-if((Get-rsRole -Value $env:COMPUTERNAME) -eq "pull") {
-   $pullServerName = $env:COMPUTERNAME
-   chdir "C:\Windows\Temp"
-   PullServerLCM
-   Set-DscLocalConfigurationManager -Path "C:\Windows\Temp\PullServerLCM" -Verbose
-   Get-ScheduledTask -TaskName "Consistency" | Start-ScheduledTask
-   $result = Get-DscLocalConfigurationManager | ConvertTo-Json -Depth 4
-   Write-EventLog -LogName DevOps -Source LCM -EntryType Information -EventId 1000 -Message "Applying Desired State Local Configuration $result"
+if((Get-rsRole -Value $env:COMPUTERNAME) -eq "pull") 
+{
+    $pullServerName = $env:COMPUTERNAME
+    chdir "C:\Windows\Temp"
+    PullServerLCM
+    Set-DscLocalConfigurationManager -Path "C:\Windows\Temp\PullServerLCM" -Verbose
+    Get-ScheduledTask -TaskName "Consistency" | Start-ScheduledTask
+    $result = Get-DscLocalConfigurationManager | ConvertTo-Json -Depth 4
+    Write-EventLog -LogName DevOps -Source LCM -EntryType Information -EventId 1000 -Message "Applying Desired State Local Configuration $result"
 }
-else {
-   $Node = $env:COMPUTERNAME
-   $cN = "CN=" + $Node + "_enc"
-   Set-Location -Path ("C:\DevOps", $d.mR -join "\")
-   Start -Wait "C:\Program Files (x86)\Git\bin\git.exe" -ArgumentList "fetch origin $($d.branch_rsConfigs)"
-   Start -Wait "C:\Program Files (x86)\Git\bin\git.exe" -ArgumentList "merge remotes/origin/$($d.branch_rsConfigs)"
-   
-   if (!(Test-Path -Path $("C:\DevOps", $d.mR, "Certificates", "Credentials" -join '\')))
-   {
-      New-Item -Path $("C:\DevOps", $d.mR, "Certificates", "Credentials" -join '\') -ItemType directory
-   }
-   powershell.exe "C:\DevOps\rsProvisioning\makecert.exe" -r -pe -n $cN -sky exchange -ss my $("C:\DevOps", $d.mR, "Certificates\Credentials","$ObjectGuid.cer"  -join '\'), -sr localmachine, -len 2048
-   Start -Wait "C:\Program Files (x86)\Git\bin\git.exe" -ArgumentList "add $("C:\DevOps", $d.mR, "Certificates\Credentials","$ObjectGuid.cer"  -join '\')"
-   Start -Wait "C:\Program Files (x86)\Git\bin\git.exe" -ArgumentList "commit -a -m `"pushing $ObjectGuid.crt`""
-
+else 
+{
+    $Node = $env:COMPUTERNAME
+    $cN = "CN=" + $Node + "_enc"
+    Set-Location -Path ("C:\DevOps", $d.mR -join "\")
+    Start -Wait "C:\Program Files (x86)\Git\bin\git.exe" -ArgumentList "fetch origin $($d.branch_rsConfigs)"
+    Start -Wait "C:\Program Files (x86)\Git\bin\git.exe" -ArgumentList "merge remotes/origin/$($d.branch_rsConfigs)"
+    
+    if (!(Test-Path -Path $("C:\DevOps", $d.mR, "Certificates", "Credentials" -join '\')))
+    {
+       New-Item -Path $("C:\DevOps", $d.mR, "Certificates", "Credentials" -join '\') -ItemType directory
+    }
+    
+    if ( -not (Get-ChildItem Cert:\LocalMachine\My | Where-Object { $_.PrivateKey.KeySize -eq 2048 -and $_.Subject -eq $cN}))
+    {
+        powershell.exe "C:\DevOps\rsProvisioning\makecert.exe" -r -pe -n $cN -sky exchange -ss my $("C:\DevOps", $d.mR, "Certificates\Credentials","$ObjectGuid.cer"  -join '\'), -sr localmachine, -len 2048
+        Start -Wait "C:\Program Files (x86)\Git\bin\git.exe" -ArgumentList "add $("C:\DevOps", $d.mR, "Certificates\Credentials","$ObjectGuid.cer"  -join '\')"
+        Start -Wait "C:\Program Files (x86)\Git\bin\git.exe" -ArgumentList "commit -a -m `"pushing $ObjectGuid.crt`""
+    }
+    
     # Add a random wait between cert sync attempts, if any of the git commands return a non-zero exit code
     #
     $certSyncRetries = 5
@@ -88,7 +96,7 @@ else {
         $gitFetch = Start-Process -PassThru -Wait "C:\Program Files (x86)\Git\bin\git.exe" -ArgumentList "fetch origin $($d.branch_rsConfigs)"
         $gitMerge = Start-Process -PassThru -Wait "C:\Program Files (x86)\Git\bin\git.exe" -ArgumentList "merge remotes/origin/$($d.branch_rsConfigs)"    
         $gitPush = Start-Process -PassThru -Wait "C:\Program Files (x86)\Git\bin\git.exe" -ArgumentList "push origin $($d.branch_rsConfigs)"
-
+    
         if (($gitFetch.ExitCode -eq 0) -and ($gitMerge.ExitCode -eq 0) -and ($gitPush.ExitCode -eq 0))
         {
             $gitSyncSuccess = $true
@@ -102,7 +110,7 @@ else {
         }
         $certSyncAttempt += 1
     } Until (($certSyncAttempt -eq $certSyncRetries) -or ($gitSyncSuccess))
-
+    
     if ($gitSyncSuccess)
     {
         Write-EventLog -LogName DevOps -Source LCM -EntryType Information -EventId 1000 -Message "Client certificate push complete after $certSyncAttempt attempt(s).`n Git FETCH: $($gitFetch.ExitCode) `n Git MERGE: $($gitMerge.ExitCode) `n Git PUSH: $($gitPush.ExitCode)"
@@ -111,15 +119,15 @@ else {
     {
         Write-EventLog -LogName DevOps -Source LCM -EntryType Error -EventId 1000 -Message "Client certificate push failed after $certSyncAttempt attempts. `n Please Re-run rsLCM process manually to correct this as client MOF will not be generated for this host.`n Git FETCH: $($gitFetch.ExitCode) `n Git MERGE: $($gitMerge.ExitCode) `n Git PUSH: $($gitPush.ExitCode)"
     }
-   
-   chdir "C:\Windows\Temp"
-   $pullServerName = $pullServerInfo.pullServerName
-   $pullServerUri = "https://" + $pullServerName + ":8080/PSDSCPullServer.svc"
-   $certThumbPrint = (Get-ChildItem Cert:\LocalMachine\My | Where-Object { $_.PrivateKey.KeySize -eq 2048 -and $_.Subject -eq $cN}).Thumbprint
-   ClientLCM -Node $Node -pullServerUri $pullServerUri -ObjectGuid $ObjectGuid -CertificateID $certThumbPrint -OutputPath "C:\Windows\Temp"
-   Set-DscLocalConfigurationManager -Path "C:\Windows\Temp" -Verbose
-   Get-ScheduledTask -TaskName "Consistency" | Start-ScheduledTask
-   $result = Get-DscLocalConfigurationManager | ConvertTo-Json -Depth 4
-   Write-EventLog -LogName DevOps -Source LCM -EntryType Information -EventId 1000 -Message "Applying Desired State Local Configuration $result"
+    
+    chdir "C:\Windows\Temp"
+    $pullServerName = $pullServerInfo.pullServerName
+    $pullServerUri = "https://" + $pullServerName + ":8080/PSDSCPullServer.svc"
+    $certThumbPrint = (Get-ChildItem Cert:\LocalMachine\My | Where-Object { $_.PrivateKey.KeySize -eq 2048 -and $_.Subject -eq $cN}).Thumbprint
+    ClientLCM -Node $Node -pullServerUri $pullServerUri -ObjectGuid $ObjectGuid -CertificateID $certThumbPrint -OutputPath "C:\Windows\Temp"
+    Set-DscLocalConfigurationManager -Path "C:\Windows\Temp" -Verbose
+    Get-ScheduledTask -TaskName "Consistency" | Start-ScheduledTask
+    $result = Get-DscLocalConfigurationManager | ConvertTo-Json -Depth 4
+    Write-EventLog -LogName DevOps -Source LCM -EntryType Information -EventId 1000 -Message "Applying Desired State Local Configuration $result"
 }
 

--- a/rsLCM.ps1
+++ b/rsLCM.ps1
@@ -43,6 +43,8 @@ Configuration PullServerLCM
 . "$("C:\DevOps", $d.mR, 'PullServerInfo.ps1' -join '\' )"
 New-rsEventLogSource -logSource LCM
 
+$gitPath = "C:\Program Files (x86)\Git\bin\git.exe"
+
 if(Test-rsCloud) {
    $ObjectGuid = (Get-rsXenInfo -value name) -replace "instance-", ""
 }
@@ -63,19 +65,56 @@ else {
    $Node = $env:COMPUTERNAME
    $cN = "CN=" + $Node + "_enc"
    Set-Location -Path ("C:\DevOps", $d.mR -join "\")
-   Start -Wait "C:\Program Files (x86)\Git\bin\git.exe" -ArgumentList "fetch origin $($d.branch_rsConfigs)"
-   Start -Wait "C:\Program Files (x86)\Git\bin\git.exe" -ArgumentList "merge remotes/origin/$($d.branch_rsConfigs)"
+   Start -Wait $gitPath -ArgumentList "fetch origin $($d.branch_rsConfigs)"
+   Start -Wait $gitPath -ArgumentList "merge remotes/origin/$($d.branch_rsConfigs)"
    
    if (!(Test-Path -Path $("C:\DevOps", $d.mR, "Certificates", "Credentials" -join '\')))
    {
       New-Item -Path $("C:\DevOps", $d.mR, "Certificates", "Credentials" -join '\') -ItemType directory
    }
    powershell.exe "C:\DevOps\rsProvisioning\makecert.exe" -r -pe -n $cN -sky exchange -ss my $("C:\DevOps", $d.mR, "Certificates\Credentials","$ObjectGuid.cer"  -join '\'), -sr localmachine, -len 2048
-   Start -Wait "C:\Program Files (x86)\Git\bin\git.exe" -ArgumentList "add $("C:\DevOps", $d.mR, "Certificates\Credentials","$ObjectGuid.cer"  -join '\')"
-   Start -Wait "C:\Program Files (x86)\Git\bin\git.exe" -ArgumentList "commit -a -m `"pushing $ObjectGuid.crt`""
+   Start -Wait $gitPath -ArgumentList "add $("C:\DevOps", $d.mR, "Certificates\Credentials","$ObjectGuid.cer"  -join '\')"
+   Start -Wait $gitPath -ArgumentList "commit -a -m `"pushing $ObjectGuid.crt`""
+   
+   <# Commenting out below commands as they have been replaced by new logic below
    Start -Wait "C:\Program Files (x86)\Git\bin\git.exe" -ArgumentList "fetch origin $($d.branch_rsConfigs)"
    Start -Wait "C:\Program Files (x86)\Git\bin\git.exe" -ArgumentList "merge remotes/origin/$($d.branch_rsConfigs)"
    Start -Wait "C:\Program Files (x86)\Git\bin\git.exe" -ArgumentList "push origin $($d.branch_rsConfigs)"
+   #>
+   
+   # Add a random wait between cert sync attempts, if any of the git commands return a non-zero exit code
+   #
+    $certSyncRetries = 5
+    $certSyncAttempt = 0
+    
+    Do
+    {
+        $gitFetch = Start-Process -WindowStyle Hidden -PassThru -Wait $gitPath -ArgumentList commit "fetch origin $($d.branch_rsConfigs)"
+        $gitMerge = Start-Process -WindowStyle Hidden -PassThru -Wait $gitPath -ArgumentList commit "merge remotes/origin/$($d.branch_rsConfigs)"    
+        $gitPush = Start-Process -WindowStyle Hidden -PassThru -Wait $gitPath -ArgumentList commit "push origin $($d.branch_rsConfigs)"
+
+        if (($gitFetch.ExitCode -eq 0) -or ($gitMerge.ExitCode -eq 0) -or ($gitPush.ExitCode -eq 0))
+        {
+            $gitSyncSuccess = $true
+        }
+        else
+        {
+            $gitSyncSuccess = $false
+            Write-EventLog -LogName DevOps -Source LCM -EntryType Error -EventId 1000` -Message "Client certificate git push attempt failed... `n Git FETCH: $($gitFetch.ExitCode) `n Git MERGE: $($gitMerge.ExitCode) `n Git PUSH: $($gitPush.ExitCode) `n Attempt: $certSyncAttempt"
+            Start-Sleep (Get-Random -Minimum 15 -Maximum 120)
+        }
+        $certSyncAttempt += 1
+    } Until (($certSyncAttempt -eq $certSyncRetries) -or ($gitSyncSuccess))
+
+    if (($gitSyncSuccess))
+    {
+        Write-EventLog -LogName DevOps -Source LCM -EntryType Information -EventId 1000` -Message "Client certificate push complete after $certSyncRetries attempt(s)."
+    }
+    else 
+    {
+        Write-EventLog -LogName DevOps -Source LCM -EntryType Error -EventId 1000` -Message "Client certificate push failed after $certSyncRetries attempts. `n Please Re-run rsLCM process manually to correct this as client MOF will not be generated for this host."
+    }
+   
    chdir "C:\Windows\Temp"
    $pullServerName = $pullServerInfo.pullServerName
    $pullServerUri = "https://" + $pullServerName + ":8080/PSDSCPullServer.svc"

--- a/rsLCM.ps1
+++ b/rsLCM.ps1
@@ -100,7 +100,7 @@ else {
         else
         {
             $gitSyncSuccess = $false
-            Write-EventLog -LogName DevOps -Source LCM -EntryType Error -EventId 1000` -Message "Client certificate git push attempt failed... `n Git FETCH: $($gitFetch.ExitCode) `n Git MERGE: $($gitMerge.ExitCode) `n Git PUSH: $($gitPush.ExitCode) `n Attempt: $certSyncAttempt"
+            Write-EventLog -LogName DevOps -Source LCM -EntryType Error -EventId 1000 -Message "Client certificate git push attempt failed... `n Git FETCH: $($gitFetch.ExitCode) `n Git MERGE: $($gitMerge.ExitCode) `n Git PUSH: $($gitPush.ExitCode) `n Attempt: $certSyncAttempt"
             Start-Sleep (Get-Random -Minimum 15 -Maximum 120)
         }
         $certSyncAttempt += 1
@@ -108,11 +108,11 @@ else {
 
     if (($gitSyncSuccess))
     {
-        Write-EventLog -LogName DevOps -Source LCM -EntryType Information -EventId 1000` -Message "Client certificate push complete after $certSyncRetries attempt(s)."
+        Write-EventLog -LogName DevOps -Source LCM -EntryType Information -EventId 1000 -Message "Client certificate push complete after $certSyncRetries attempt(s)."
     }
     else 
     {
-        Write-EventLog -LogName DevOps -Source LCM -EntryType Error -EventId 1000` -Message "Client certificate push failed after $certSyncRetries attempts. `n Please Re-run rsLCM process manually to correct this as client MOF will not be generated for this host."
+        Write-EventLog -LogName DevOps -Source LCM -EntryType Error -EventId 1000 -Message "Client certificate push failed after $certSyncRetries attempts. `n Please Re-run rsLCM process manually to correct this as client MOF will not be generated for this host."
     }
    
    chdir "C:\Windows\Temp"


### PR DESCRIPTION
Contains the following changes:
- Additional logic to not generate certificate if a valid instance of one exists. Related to issue #42 
- Added retry logic if a git operation fails when uploading client cert, with additional LCM logging to help track this in DevOps log. Related to issue #30 
- Updated indentation to 4 spaces
- Replaced '?' alias with full Where-Object cmdlet for clarity